### PR TITLE
chore(deps): require Node 22+ for chalk 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Interactive CLI tool for exec into AWS ECS tasks (containers), rollback services
 > [!WARNING]
 > Make sure you have met the [Amazon ECS Exec prerequisites](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/ecs-exec.html#ecs-exec-prereq).
 
-- Node.js 18+
+- Node.js 22+
 - AWS CLI v2
 - AWS Session Manager Plugin
 - AWS credentials configured (supports AWS SSO, access keys, etc.)

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "semantic-release": "^25.0.8"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@actions/core": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "homepage": "https://github.com/SchematicHQ/taskonaut#readme",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-ecs": "^3.1098.0",


### PR DESCRIPTION
Stacked onto `dependabot/npm_and_yarn/chalk-6.0.0` (#502) so the engines bump lands on that PR before it merges. Requested in #inner-orbit after the 2026-08-03 dependabot sweep flagged #502 as Medium risk.

chalk 6.0.0 drops Node < 22, but `engines.node` still advertised `>=18.0.0` and the README listed Node.js 18+. Since taskonaut ships as an installable CLI (`@schematichq/taskonaut` bin), a Node 18–21 user would install it successfully and then hit a startup crash.

- `package.json` / `package-lock.json`: `engines.node` `>=18.0.0` → `>=22.0.0`
- `README.md`: prereq `Node.js 18+` → `Node.js 22+`

## Verified locally

On **Node 24.18.0** (in the CI matrix), against this branch: `npm ci`, `npm run lint`, `npm test` (3/3 pass), `prettier --check` on the files I touched.

On **Node 18.20.8**, packing the tarball before vs. after the change:

| | before (`>=18.0.0`) | after (`>=22.0.0`) |
|---|---|---|
| `npm install` (default) | no warning about taskonaut itself | `EBADENGINE ... package: @schematichq/taskonaut, required: >=22.0.0` |
| `npm install` (`engine-strict=true`) | fails, blaming `@aws-sdk/client-ecs` | fails, correctly naming `@schematichq/taskonaut` |

And the breakage this guards against, on Node 18 with chalk 6 installed:

```
$ node ./node_modules/@schematichq/taskonaut/index.js --help
SyntaxError: Invalid regular expression flags
    at ModuleLoader.moduleStrategy (node:internal/modules/esm/translators:152:18)
```

Not verified: nothing on real Node 20/22 runtimes (only 18 and 24 were available here), and the Test workflow will not run on this PR — it triggers only on `pull_request: branches: [main]`. That is why I ran the full CI step list locally.

---

## ⚠️ The release will ship this breakage as a patch

This is the part worth your attention, and it is not fixed by this diff.

I ran `@semantic-release/commit-analyzer` against this repo's own `.releaserc.json`. The custom `releaseRules` entry `{type: chore, scope: deps, release: patch}` is matched **before** the default `{breaking: true, release: major}` rule, so a breaking marker on a `chore(deps)` commit is silently downgraded:

```
patch  <- chore(deps): require Node 22+
patch  <- chore(deps)!: require Node 22+
patch  <- chore(deps): require Node 22+      [+BREAKING CHANGE footer]
major  <- chore(engines)!: require Node 22+  [+BREAKING CHANGE footer]
major  <- feat!: / fix!: / chore!:           [+BREAKING CHANGE footer]
patch  <- refactor!:                         [+BREAKING CHANGE footer]   <-- same bug
```

(Under stock `conventionalcommits` rules every one of those `!`/footer cases is `major`.)

So as things stand, #502 squash-merges as `chore(deps): bump chalk from 5.6.2 to 6.0.0` → **1.10.6**, and every Node 18–21 user on `^1` auto-upgrades into the crash above. Adding a `BREAKING CHANGE:` footer to my commit would not help — the scope is what traps it.

**Suggested fix:** before squash-merging, retitle **#502** to something like `chore(engines)!: bump chalk to 6.0.0 and require Node 22+` with a `BREAKING CHANGE:` footer, so semantic-release cuts **2.0.0** and `^1` users are protected. The PR title is what matters, since this repo squash-merges.

I did not amend my own commit for this: the merge path here is #502's title, not mine, and I was scoped to not rewrite pushed history. Happy to redo it however you prefer.

Separately, the `releaseRules` swallowing breaking changes on `chore(deps)` and `refactor` looks like a latent bug worth its own PR — adding `{breaking: true, release: "major"}` as the first rule would fix it.

## Base branch

Merging this into the dependabot branch is the one-click path, but dependabot force-pushes on rebase, which would orphan it. Retargeting to `main` also works — the engines bump stands on its own, since the AWS SDK deps already require Node >=20 and CI is 22.x/24.x only.

## One more unrelated thing

`npm run format` is `prettier --write`, so the CI "Check formatting" step rewrites files and exits 0 instead of failing. There is real prettier drift on `CHANGELOG.md`, `CONTRIBUTING.md`, `index.js`, and `README.md` that CI is silently hiding. I reverted the rewrites it made in my tree to keep this diff to three lines.