### PR TITLE
chore(deps): re-resolve js-yaml to patched versions (GHSA-5p4m-2wfm-xmqj)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1721,9 +1721,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9160,9 +9160,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Clears the two open `js-yaml` Dependabot security alerts on `package-lock.json`. Lockfile only — `package.json` is untouched, no `overrides` needed, no behavioral change.

Both `js-yaml` copies are transitive devDependencies whose parents already declare ranges that admit the patched release, so a plain lockfile re-resolution (`npm update js-yaml --package-lock-only`) is enough. Each copy stays inside its own major — no cross-major drag.

### Cleared

- GHSA-5p4m-2wfm-xmqj — `js-yaml` — high — `3.15.0` → `3.15.1` — lockfile re-resolution (nested under `@istanbuljs/load-nyc-config`, whose range is `^3.13.1`)
- GHSA-5p4m-2wfm-xmqj — `js-yaml` — high — `4.3.0` → `4.3.1` — lockfile re-resolution (hoisted, reached via `cosmiconfig`'s `^4.1.0`)

### Not fixed — unfixable for now

The other six open alerts on this repo point at copies bundled *inside* the `npm` CLI package (`inBundle: true` in the lockfile), reached via `@semantic-release/npm@13 → npm@^11.6.2`. npm `overrides` cannot rewrite bundled dependencies, and `npm@11.19.0` (the newest release inside `^11.6.2`) still bundles the vulnerable versions, so bumping npm does not help either. Only a behavioral change — dropping or replacing `@semantic-release/npm` — would clear them, which is out of scope for a security-only sweep.

- GHSA-mwp4-54f8-5fhr — `ip-address` — high — bundled `npm/node_modules/ip-address@10.2.0`
- GHSA-4xrf-jv44-h6hh — `ip-address` — medium — same bundled copy
- GHSA-22jq-vg5j-6vgg — `ip-address` — medium — same bundled copy
- GHSA-8xcm-r25x-g524 — `undici` — medium — bundled `npm/node_modules/undici@6.27.0`
- GHSA-m8rv-5g2x-5cg5 — `undici` — medium — same bundled copy
- GHSA-v3r7-h72x-cjcm — `undici` — medium — same bundled copy

(The top-level `undici` is already `6.28.0` and `@semantic-release/github` resolves `7.29.0` — both outside the `< 6.28.0` range, so the alerts are the bundled copy only.)

### Verification

- `npm ls js-yaml --all` reports exactly `js-yaml@3.15.1` (nested) and `js-yaml@4.3.1` (hoisted); no vulnerable copy remains on disk after `npm ci`.
- `npm audit` no longer lists `js-yaml`. The remaining findings are the bundled-npm-CLI ones above (plus `brace-expansion`/`tar` inside the same bundle, which are not separately alerted).
- `npm run lint` (eslint) — clean.
- `npm test` (jest) — 3/3 passing. This exercises the v3 copy, since `@istanbuljs/load-nyc-config` is jest's coverage-config loader.
