### PR TITLE
chore(release): migrate npm publishing to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  id-token: write
 
 jobs:
   release:
@@ -20,6 +21,7 @@ jobs:
       - uses: actions/setup-node@v7.0.0
         with:
           node-version: lts/*
+          registry-url: "https://registry.npmjs.org"
       - run: npm install
       - run: npm run lint
       - run: npm run format
@@ -28,5 +30,7 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # Disable npm provenance attestation: it requires a GitHub-hosted
+          # runner and we use a self-hosted RunsOn runner. OIDC auth still works.
+          NPM_CONFIG_PROVENANCE: "false"
         run: npm run semantic-release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -84,6 +84,13 @@
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ],
-    "@semantic-release/github"
+    [
+      "@semantic-release/github",
+      {
+        "failComment": false,
+        "failTitle": false,
+        "successComment": false
+      }
+    ]
   ]
 }


### PR DESCRIPTION
Migrates npm publishing to OIDC trusted publishing, matching schematic-icons and schematic-js.

[Run 32200022966](https://github.com/SchematicHQ/taskonaut/actions/runs/32200022966) failed because the `NPM_TOKEN` secret no longer authenticates (`401 GET /-/whoami`) and `@semantic-release/npm` 13 could not fall back to OIDC — `release.yml` never granted `id-token: write`. `@schematichq/taskonaut` has not published since 1.10.5 on 2025-11-24.

Changes:

- `release.yml`: add `id-token: write`, set `registry-url`, drop `NPM_TOKEN`, and set `NPM_CONFIG_PROVENANCE: "false"` — npm refuses provenance attestation off a self-hosted runner (`E422`), and taskonaut releases on `runner=1cpu-linux-arm64`. schematic-icons needed the same line (SchematicHQ/schematic-icons#23).
- `.releaserc.json`: `failComment` / `failTitle` / `successComment: false` on `@semantic-release/github`, because the failure path tries to open an issue labelled `semantic-release` and is itself rejected (`Validation Failed … "resource":"Label"`), burying the real error.

**Still needed before merge:** register the trusted publisher for `@schematichq/taskonaut` on npmjs.com (GitHub Actions, `SchematicHQ/taskonaut`, workflow `release.yml`). Without it the OIDC exchange fails even with `id-token: write`.

Unrelated, left alone: `release.config.mjs` is dead config — cosmiconfig resolves `.releaserc.json` first. Worth deleting separately.
