### PR TITLE
chore(ci): skip release on chore(*) merges

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ permissions:
 
 jobs:
   release:
+    # Skip releases for chore(*) merges (dependabot bumps, release commits).
+    # These ride along with the next real feat/fix release instead.
+    if: ${{ !startsWith(github.event.head_commit.message, 'chore(') || github.event_name == 'workflow_dispatch' }}
     runs-on: runs-on=${{ github.run_id }}/runner=1cpu-linux-arm64
     steps:
       - uses: actions/checkout@v7.0.1


### PR DESCRIPTION
Dependabot bumps land on main as `chore(deps): ...` and `.releaserc.json` maps that to a patch release, so every minor dep update cuts a version. Gate the release job on the head commit message the same way `schematic-api`'s `main.yml` does.

Those commits still show up in the changelog — they just wait for the next real feat/fix release instead of triggering their own. `workflow_dispatch` still forces a release.