### PR TITLE
fix(config): use select prompt type for inquirer 14

### DIFF
--- a/index.js
+++ b/index.js
@@ -1925,7 +1925,7 @@ program
 
           const { profile } = await inquirer.prompt([
             {
-              type: "list",
+              type: "select",
               name: "profile",
               message: chalk.blue("Select AWS Profile:"),
               prefix: "🔑",
@@ -1939,7 +1939,7 @@ program
 
           const { region } = await inquirer.prompt([
             {
-              type: "list",
+              type: "select",
               name: "region",
               message: chalk.blue("Select AWS Region:"),
               prefix: "🌎",


### PR DESCRIPTION
inquirer ^14 dropped the legacy "list" prompt type in favor of "select".

Change our usage to "select"; choices and default are unchanged.
